### PR TITLE
Migrate CI from Coq 8.x Docker to Rocq 9.1 Nix

### DIFF
--- a/.github/workflows/coq-ci.yml
+++ b/.github/workflows/coq-ci.yml
@@ -5,23 +5,15 @@ on: [push, pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        image:
-          - 'coqorg/coq:8.19'
-          - 'coqorg/coq:8.18'
-          - 'coqorg/coq:8.17'
-          - 'coqorg/coq:8.16'
-          - 'coqorg/coq:8.15'
-          - 'coqorg/coq:8.14'
-      fail-fast: false
+    permissions:
+      contents: read
+      id-token: write
     steps:
-      - uses: actions/checkout@v2
-      - uses: coq-community/docker-coq-action@v1
-        with:
-          opam_file: 'coq-cds4ltl.opam'
-          custom_image: ${{ matrix.image }}
+      - uses: actions/checkout@v4
+      - uses: DeterminateSystems/nix-installer-action@v21
+      - uses: DeterminateSystems/magic-nix-cache-action@v13
+      - run: nix build
 
 # See also:
-# https://github.com/coq-community/docker-coq-action#readme
-# https://github.com/erikmd/docker-coq-github-action-demo
+# https://github.com/DeterminateSystems/nix-installer-action
+# https://github.com/DeterminateSystems/magic-nix-cache-action

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,7 +3,7 @@
 ## Project Overview
 
 **Project:** coq-cds4ltl - A Calculational Deductive System for Linear Temporal Logic
-**Language:** Coq 8.14-8.19
+**Language:** Rocq 9.1
 **Domain:** Formal verification of Linear Temporal Logic (LTL)
 **Paper:** "A Calculational Deductive System for Linear Temporal Logic" - Warford, Vega, Staley (ACM Computing Surveys, Vol. 53, No. 3, June 2020)
 **Repository:** https://github.com/jwiegley/coq-cds4ltl
@@ -15,16 +15,16 @@ Formalize the axiomatization of Linear Temporal Logic using minimal axioms (Hunt
 ## Tech Stack & Dependencies
 
 ### Core Requirements
-- **Coq:** 8.14-8.19 (default: 8.19)
+- **Rocq:** 9.1
 - **OCaml:** Required for Coq compilation
-- **Build System:** `coq_makefile` + GNU Make
+- **Build System:** `rocq makefile` + GNU Make
 - **Package Manager:** OPAM or Nix flakes
 
 ### Environment Setup
 
 #### Using Nix (Recommended)
 ```bash
-nix develop                  # Enter development shell with Coq 8.19
+nix develop                  # Enter development shell with Rocq 9.1
 nix build                    # Build the project
 nix flake check             # Run all checks
 ```
@@ -32,23 +32,22 @@ nix flake check             # Run all checks
 #### Using OPAM
 ```bash
 opam switch create coq-cds4ltl 4.14.1
-opam repo add coq-released https://coq.inria.fr/opam/released
-opam install coq.8.19.0
+opam install rocq-prover.9.1.0
 make
 ```
 
-### Coq Standard Library Modules Used
+### Rocq Standard Library Modules Used
 ```coq
-Coq.Unicode.Utf8          (* Unicode notation *)
-Coq.Program.Program       (* Program tactics *)
-Coq.Classes.Morphisms     (* Proper instances *)
-Coq.Setoids.Setoid       (* Setoid rewriting *)
-Coq.Sets.Ensembles       (* Classical set theory *)
-Coq.Sets.Classical_sets  (* Classical set operations *)
-Coq.Sets.Powerset_facts  (* Powerset operations *)
-Coq.Logic.Classical      (* Law of excluded middle *)
-Coq.micromega.Lia        (* Linear arithmetic *)
-Coq.Lists.List           (* List operations - used in Step.v *)
+Stdlib.Unicode.Utf8          (* Unicode notation *)
+Stdlib.Program.Program       (* Program tactics *)
+Stdlib.Classes.Morphisms     (* Proper instances *)
+Stdlib.Setoids.Setoid       (* Setoid rewriting *)
+Stdlib.Sets.Ensembles       (* Classical set theory *)
+Stdlib.Sets.Classical_sets  (* Classical set operations *)
+Stdlib.Sets.Powerset_facts  (* Powerset operations *)
+Stdlib.Logic.Classical      (* Law of excluded middle *)
+Stdlib.micromega.Lia        (* Linear arithmetic *)
+Stdlib.Lists.List           (* List operations - used in Step.v *)
 ```
 
 ### No External Dependencies
@@ -264,7 +263,7 @@ grep -r "Admitted"      # Find admitted proofs (14 expected in LTL.v)
 - **Type checking:** All proofs verified by Coq
 - **Admitted detection:** Makefile checks for `admit`, `undefined`, `jww`
 - **Completeness:** ~94% proven (14 Admitted out of 240+, concentrated in R/M/OLD sections)
-- **CI Matrix:** Tests on Coq 8.14-8.19 plus dev version
+- **CI Matrix:** Builds with Rocq 9.1 via Nix
 
 ## Performance & Optimization
 
@@ -403,7 +402,7 @@ Proof. matches. as_if. reduce. just_math. Qed.
 ## Version History
 
 - **Current:** Active development (20+ recent commits)
-- **Coq Support:** 8.14-8.19
+- **Rocq Support:** 9.1
 - **Last Major Update:** See git log for recent changes
 
 ---

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-COQ_MAKEFILE := $(shell command -v coq_makefile 2>/dev/null || echo "rocq makefile")
+COQ_MAKEFILE := rocq makefile
 
 MISSING	 =									\
 	find . \( \( -name foo \) -prune \)					\

--- a/coq-cds4ltl.opam
+++ b/coq-cds4ltl.opam
@@ -15,18 +15,13 @@ paper: A Calculational Deductive System for Linear Temporal Logic (CDS4LTL).
 build: [make "-j%{jobs}%" ]
 install: [make "install"]
 depends: [
-  "coq" {(>= "8.14" & < "8.20~") | (= "dev")}
+  "rocq-core" {>= "9.1" & < "9.2~"}
+  "rocq-stdlib" {>= "9.1" & < "9.2~"}
 ]
-
-url {
-  src: "https://github.com/jwiegley/coq-cds4ltl/archive/refs/tags/1.0.0.tar.gz"
-  checksum: "sha256=7a0beafad11ca48775e404cabe25e5790d2c7ea59ef84aadf191a5e2d5b6e76a"
-}
 
 tags: [
   "keyword: temporal logic"
   "category: Mathematics/Logic/Modal logic"
-  "date: 2022-07-23"
   "logpath: CDS4LTL"
 ]
 authors: [


### PR DESCRIPTION
## Summary

- Replace Docker-based 6-version CI matrix (Coq 8.14–8.19, all failing) with Nix-based build using DeterminateSystems actions
- Update opam dependencies from `coq` to `rocq-core` + `rocq-stdlib` >= 9.1
- Simplify Makefile to use `rocq makefile` directly
- Update CLAUDE.md to reflect Rocq 9.1 as the baseline

## Context

All CI has been failing because the source code already uses Rocq 9.1's `Stdlib.*` imports, but CI was still testing against Coq 8.14–8.19 Docker images (which no longer exist on Docker Hub). The `flake.nix` already targets `rocqPackages_9_1` and builds successfully.

## Test plan

- [x] Verified `nix build` passes locally with all 10 `.v` files compiling
- [ ] CI should pass on this PR using the new Nix-based workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)