### PR TITLE
Resolve both aborted theorems

### DIFF
--- a/src/Bool.v
+++ b/src/Bool.v
@@ -501,12 +501,25 @@ Qed.
 
 Theorem mccune p q r s : ¬(¬(¬(p ∨ q) ∨ r) ∨ ¬(p ∨ ¬(¬r ∨ ¬(r ∨ s)))) ≈ r.
 Proof.
-  pose proof (huntington (¬r) (¬(p ∨ q) ∨ (¬r ∧ ¬s))).
-  apply not_swap in H.
-  revert H.
-  rewrite !not_or.
-  rewrite !not_and.
+  rewrite (not_or (¬r) (¬(r ∨ s))).
   rewrite !not_not.
-Abort.
+  rewrite and_absorb.
+  rewrite not_or.
+  rewrite !not_not.
+  rewrite not_or.
+  rewrite and_or_r.
+  rewrite (or_comm p r).
+  rewrite and_absorb.
+  rewrite and_or.
+  rewrite (and_comm (¬p ∧ ¬q) p).
+  rewrite <- and_assoc.
+  rewrite absurdity.
+  rewrite false_and.
+  rewrite or_false.
+  rewrite (and_comm (¬p ∧ ¬q) r).
+  rewrite or_comm.
+  rewrite or_absorb.
+  reflexivity.
+Qed.
 
 End BooleanLogicFacts.

--- a/src/Model.v
+++ b/src/Model.v
@@ -752,15 +752,12 @@ Proof.
   apply H, H0.
 Qed.
 
-Theorem (* NEW *) impossible p q : (p ⇒ q) ⟹ (◯ p ⇒ ◯ q).
-Proof.
-  rewrite <- next_impl.
-  unfold implies, next, always.
-  repeat intro; reduce.
-  destruct H.
-Abort.
+(* The pointwise implication (p ⇒ q) ⟹ (◯ p ⇒ ◯ q) is NOT valid:
+   knowing ¬p(n) ∨ q(n) at point n does not imply ¬p(n+1) ∨ q(n+1).
+   Counterexample: p = {1}, q = ∅. Then (p ⇒ q) = {n | n ≠ 1} contains 0,
+   but (◯ p ⇒ ◯ q) = {n | n ≠ 0} does not.
 
-(* Without □ this unfolds to:
+   Without □ this unfolds to:
 
      ∀ x, (p x ⇒ q x) ⟹ (◯ p) x ⇒ (◯ q) x
 
@@ -768,6 +765,22 @@ Abort.
 
      ∀ x, (∀ y, p y ⇒ q y) ⟹ (◯ p) x ⇒ (◯ q) x
  *)
+Theorem (* NEW *) impossible_false : ¬(∀ p q, (p ⇒ q) ⟹ (◯ p ⇒ ◯ q)).
+Proof.
+  intro H.
+  specialize (H (Singleton nat 1) (Empty_set nat)).
+  unfold implies in H.
+  specialize (H 0).
+  assert (Hprem : Union nat (Complement nat (Singleton nat 1)) (Empty_set nat) 0).
+  { left. intro Habs. inversion Habs. }
+  specialize (H Hprem); clear Hprem.
+  inversion H as [n Hn | n Hn]; subst; clear H.
+  - apply Hn.
+    unfold next, shift; simpl.
+    exact (In_singleton nat 1).
+  - unfold next, shift in Hn; simpl in Hn.
+    inversion Hn.
+Qed.
 Theorem (* NEW *) internal p q : □ (p ⇒ q) ⟹ (◯ p ⇒ ◯ q).
 Proof.
   rewrite <- next_impl.


### PR DESCRIPTION
## Summary

- **Prove McCune's single axiom** (`mccune` in Bool.v): derives `¬(¬(¬(p ∨ q) ∨ r) ∨ ¬(p ∨ ¬(¬r ∨ ¬(r ∨ s)))) ≈ r` from Huntington's three axioms via De Morgan laws, absorption, and distribution
- **Disprove pointwise implication over Next** (`impossible` in Model.v): proves `¬(∀ p q, (p ⇒ q) ⟹ (◯ p ⇒ ◯ q))` with counterexample p = {1}, q = ∅ in the semantic model

Both theorems were previously left as `Abort`. The repository now has zero `Abort` and zero `Admitted` proofs.

## Test plan

- [x] Full project builds cleanly with `make -j4`
- [x] No `Abort`, `Admitted`, or `admit` remaining in source
- [x] Both proofs end with `Qed` (no axioms or admits used)

🤖 Generated with [Claude Code](https://claude.com/claude-code)